### PR TITLE
Added some command line cosmetics

### DIFF
--- a/image_to_json.py
+++ b/image_to_json.py
@@ -1,23 +1,72 @@
 #!/usr/bin/env python
+"""Converts image to json-like file.
 """
-Opens image and converts to csv data using the PIL library
-"""
+
+
+import os
+import sys
+import getopt
 
 import Image
-from sys import argv, exit
 import json
 
-if len(argv) != 2:
-    print "USAGE: python image_to_csv.py *image_name*"
-    exit()
 
-image = Image.open(argv[1])
-pixels = list(image.getdata())
-width, height = image.size
-pixels = [pixels[i * width:(i + 1) * width] for i in range(height)]
+params = {'sname': os.path.basename(sys.argv[0]),
+          'h':('-h', '--help'),
+          'i':', '.join(('-i IMAGE', '--input=IMAGE')),
+          'idesc': 'Input image file, parsed using PIL library',
+          'o':', '.join(('-o IMAGE', '--output=IMAGE')),
+          'odesc': 'Output file, *.json',
+          'fill':' ',
+          'align':'<',
+          'newline':'\n',
+          'width':30,
+          'start':4*' ',
+          }
 
-# Use first value if multi channel
-if type(pixels[0][0]) is not int:
-    pixels = [[p[0] for p in row] for row in pixels]
+def help_msg():
+    s = ('{newline}Usage: {sname} [options]{newline}'
+         '{newline}Options:'
+         '{newline}{start}{i:{fill}{align}{width}s}{idesc}'
+         '{newline}{start}{o:{fill}{align}{width}s}{odesc}').format(**params)
+    return s
 
-print json.dumps(pixels, indent=4)
+
+def get_pixels(fname):
+    image = Image.open(fname)
+    pixels = list(image.getdata())
+    width, height = image.size
+    pixels = [pixels[i * width:(i + 1) * width] for i in range(height)]
+    if type(pixels[0][0]) is not int:
+        pixels = [[p[0] for p in row] for row in pixels]
+    return pixels
+
+def write_json(fname, pixels):
+    with open(fname, 'w') as f:
+        return f.write(json.dumps(pixels, indent=4))
+
+if __name__ == '__main__':
+    ifile = ''
+    ofile = ''
+
+    try:
+        opts, args = getopt.getopt(sys.argv[1:], 'hi:o:',
+                                   ['help', 'input=', 'output='])
+
+    except getopt.GetoptError as err:
+        print str(err)
+        print help_msg()
+        sys.exit(1)
+
+    for opt, arg in opts:
+        if opt in ('-h', '--help'):
+            print help_msg()
+            sys.exit(0)
+
+        elif opt in ('-i', '--input'):
+            ifile = arg
+
+        elif opt in ('-o', '--output'):
+            ofile = arg
+
+    write_json(ofile, get_pixels(ifile))

--- a/json_image_to_blender.py
+++ b/json_image_to_blender.py
@@ -3,6 +3,7 @@
 Loads a file of pixel values and converts to bar heights for use in Blender.
 """
 
+import sys
 import bpy
 import json
 
@@ -66,6 +67,7 @@ def pixels_to_blender(pixels, z_scale=0.05):
 
 # Read json data and run through Blender
 if __name__ == "__main__":
-    with open("pixels.json") as indata:
+    pixels = sys.argv[-1]
+    with open(pixels) as indata:
         pixels = json.load(indata)
     pixels_to_blender(pixels)


### PR DESCRIPTION
Added command line arguments to define the input image to be parsed as json, as well as the output name and possible rescaling of it. Now to run the image_to_json.py you do it like:

``` bash
Converts image to json-like file.

Usage:
    python image_to_json.py (-i FILE) [-o FILE] [-s K] [-f FILTER]

Options:
    -h --help                   Shows this screen.
    -i FILE --input=FILE        Input image file.
    -o FILE --output=FILE       Output json file. [default: image.json]
    -s K --size=K               Resize image in K. [default: False]
    -f FILTER --filter=FILTER   Resampling filter, NEAREST, BILINEAR, BICUBIC or LANCZOS. [default: NEAREST]
```

I followed the same idea for the blender script run, where you set the input json file as an argument, running it like:

``` bash
blender -P json_image_to_blender.py -- input_pixels.json
```
