### PR TITLE
Inserted command line arguments

### DIFF
--- a/image_to_json.py
+++ b/image_to_json.py
@@ -1,23 +1,72 @@
 #!/usr/bin/env python
+"""Converts image to json-like file.
 """
-Opens image and converts to csv data using the PIL library
-"""
+
+
+import os
+import sys
+import getopt
 
 import Image
-from sys import argv, exit
 import json
 
-if len(argv) != 2:
-    print "USAGE: python image_to_csv.py *image_name*"
-    exit()
 
-image = Image.open(argv[1])
-pixels = list(image.getdata())
-width, height = image.size
-pixels = [pixels[i * width:(i + 1) * width] for i in range(height)]
+params = {'sname': os.path.basename(sys.argv[0]),
+          'h':('-h', '--help'),
+          'i':', '.join(('-i IMAGE', '--input=IMAGE')),
+          'idesc': 'Input image file, parsed using PIL library',
+          'o':', '.join(('-o IMAGE', '--output=IMAGE')),
+          'odesc': 'Output file, *.json',
+          'fill':' ',
+          'align':'<',
+          'newline':'\n',
+          'width':30,
+          'start':4*' ',
+          }
 
-# Use first value if multi channel
-if type(pixels[0][0]) is not int:
-    pixels = [[p[0] for p in row] for row in pixels]
+def help_msg():
+    s = ('{newline}Usage: {sname} [options]{newline}'
+         '{newline}Options:'
+         '{newline}{start}{i:{fill}{align}{width}s}{idesc}'
+         '{newline}{start}{o:{fill}{align}{width}s}{odesc}').format(**params)
+    return s
 
-print json.dumps(pixels, indent=4)
+
+def get_pixels(fname):
+    image = Image.open(fname)
+    pixels = list(image.getdata())
+    width, height = image.size
+    pixels = [pixels[i * width:(i + 1) * width] for i in range(height)]
+    if type(pixels[0][0]) is not int:
+        pixels = [[p[0] for p in row] for row in pixels]
+    return pixels
+
+def write_json(fname, pixels):
+    with open(fname, 'w') as f:
+        return f.write(json.dumps(pixels, indent=4))
+
+if __name__ == '__main__':
+    ifile = ''
+    ofile = ''
+
+    try:
+        opts, args = getopt.getopt(sys.argv[1:], 'hi:o:',
+                                   ['help', 'input=', 'output='])
+
+    except getopt.GetoptError as err:
+        print str(err)
+        print help_msg()
+        sys.exit(1)
+
+    for opt, arg in opts:
+        if opt in ('-h', '--help'):
+            print help_msg()
+            sys.exit(0)
+
+        elif opt in ('-i', '--input'):
+            ifile = arg
+
+        elif opt in ('-o', '--output'):
+            ofile = arg
+
+    write_json(ofile, get_pixels(ifile))

--- a/image_to_json.py
+++ b/image_to_json.py
@@ -1,49 +1,40 @@
 #!/usr/bin/env python
-"""Converts image to json-like file.
+"""usage: image_to_json.py [-h] -i INPUT [-o OUTPUT] [-s SIZE] [-f FILTER]
 
-Usage:
-    image_to_json.py (-i FILE) [-o FILE] [-s K] [-f FILTER]
+Converts image to json file.
 
-Options:
-    -h --help                   Shows this screen.
-    -i FILE --input=FILE        Input image file.
-    -o FILE --output=FILE       Output json file. [default: image.json]
-    -s K --size=K               Resize image in K. [default: False]
-    -f FILTER --filter=FILTER   Resampling filter, NEAREST, BILINEAR, BICUBIC or LANCZOS. [default: NEAREST]
+optional arguments:
+  -h, --help            show this help message and exit
+  -i INPUT, --input INPUT
+                        Input image file.
+  -o OUTPUT, --output OUTPUT
+                        Output json file.
+  -s SIZE, --size SIZE  Reduce image by a proportional factor.
+  -f FILTER, --filter FILTER
+                        Resampling filter. Can be 'nearest', 'bilinear',
+                        'bicubic', or 'lanczos'.
+
 """
 
-
-import os
-import sys
-import getopt
-from docopt import docopt
-
+import argparse
 import json
 
 from PIL import Image
 
 
-def get_filter(resample):
-    if resample.upper() == 'NEAREST':
-        f = Image.NEAREST
-    elif resample.upper() == 'BILINEAR':
-        f = Image.BILINEAR
-    elif resample.upper() == 'BICUBIC':
-        f = Image.BICUBIC
-    elif resample.upper() == 'LANCZOS':
-        f = Image.LANCZOS
-    else:
-        f = Image.NEAREST
-    return f
-
-def get_pixels(fname, size=False, resample='NEAREST'):
+def get_pixels(fname, size=1, resample='nearest'):
     image = Image.open(fname)
     width, height = image.size
 
-    if size.upper() != 'FALSE':
-        width = int(width*float(size))
-        height = int(height*float(size))
-        image = image.resize((width, height), resample=get_filter(resample))
+    if size <= 0:
+        raise ValueError("Size must be a positive value.")
+    elif size > 1:
+        raise ValueError("Size is specified as a proportion, not a percent.")
+    elif size != 1:
+        width = int(width * float(size))
+        height = int(height * float(size))
+        image = image.resize((width, height),
+                             resample=getattr(Image, resample.upper()))
 
     pixels = list(image.getdata())
     pixels = [pixels[i * width:(i + 1) * width] for i in range(height)]
@@ -53,13 +44,32 @@ def get_pixels(fname, size=False, resample='NEAREST'):
 
     return pixels
 
+
 def write_json(fname, pixels):
     with open(fname, 'w') as f:
         return f.write(json.dumps(pixels, indent=4))
 
+
 if __name__ == '__main__':
-    args = docopt(__doc__)
-    img = get_pixels(args['--input'],
-                     size=args['--size'],
-                     resample=args['--filter'])
-    write_json(args['--output'], img)
+    parser = argparse.ArgumentParser(description="Converts image to json file.")
+    parser.add_argument('i', '--input',
+                        type=str,
+                        required=True,
+                        help="Input image file.")
+    parser.add_argument('-o', '--output',
+                        type=str,
+                        default='image.json',
+                        help="Output json file.")
+    parser.add_argument('-s', '--size',
+                        type=float,
+                        default=1,
+                        help="Reduce image by a proportional factor.")
+    parser.add_argument('-f', '--filter',
+                        type=str,
+                        default='nearest',
+                        help=("Resampling filter. Can be 'nearest', "
+                              "'bilinear', 'bicubic', or 'lanczos'."))
+    args = parser.parse_args()
+
+    img = get_pixels(args.input, size=args.size, resample=args.filter)
+    write_json(args.output, img)

--- a/json_image_to_blender.py
+++ b/json_image_to_blender.py
@@ -3,6 +3,7 @@
 Loads a file of pixel values and converts to bar heights for use in Blender.
 """
 
+import sys
 import bpy
 import json
 
@@ -66,6 +67,7 @@ def pixels_to_blender(pixels, z_scale=0.05):
 
 # Read json data and run through Blender
 if __name__ == "__main__":
-    with open("pixels.json") as indata:
+    pixels = sys.argv[-1]
+    with open(pixels) as indata:
         pixels = json.load(indata)
     pixels_to_blender(pixels)


### PR DESCRIPTION
Modified from the first pull request #1 using @patrickfuller comments and suggestions. The main modification lies on using `argparse` instead of `docopt` to parse the command line arguments.
